### PR TITLE
Readme: add note about installing coffee globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Springseed provides easy note taking.
 
 You'll need node & npm installed.
 
+    npm install -g coffee-script
     npm install .
     cake -w server
 


### PR DESCRIPTION
`cake` is not available unless you have `coffee-script` installed globally. I edited the Readme file to take note of that.

Btw, have you considered having an `npm start` command instead? You can just edit package.json and add:

``` js
  "scripts": {
    "run": "cake -w server"
  },
  "devDependencies": {
    "coffee-script": "^1.7.0"
  }
```

this will automatically use `cake` as provided in your _node_modules/_.
