### PR TITLE
Removes the bug of adding categories

### DIFF
--- a/app/controllers/popover.coffee
+++ b/app/controllers/popover.coffee
@@ -20,6 +20,7 @@ class Popover extends Spine.Controller
     "click .delete-popover #deleteNotebook": "deleteNotebook"
     "click .delete-popover #renameNotebook": "renameNotebook"
     "keyup .delete-popover #addCat": "addCategory"
+    "focusout .delete-popover #addCat": "cleanField"
 
   constructor: ->
     super
@@ -28,6 +29,10 @@ class Popover extends Spine.Controller
     # Not sure where to put this, but it is global
     e.preventDefault()
     @el.hide().children().hide() if $(e.target)[0].nodeName isnt "INPUT"
+
+  cleanField: (e) ->
+    $(e.target)[0].value = ""
+
 
   addCategory: (e) ->
     if e.type is "keyup" and e.which is 13
@@ -38,6 +43,7 @@ class Popover extends Spine.Controller
       if name isnt ''
         cat.push(name)
         notebook.updateAttribute("categories", cat)
+        @cleanField(e)
 
       @el.hide()
 


### PR DESCRIPTION
### What was happening:

We are using the same DOM element `.delete-popover` to represent the popover that appears on right-clicking a note. So, whlie creating a new category, if we type in the input field specified and press `<Enter>`, the category is registered and the name of the added category remains as text in the input field (See the image posted by @fonorobert on #175). 

So, on right-clicking any note, since we are using the same pop-over, instead of the placeholder text *add category*, the name of the added category appears.

### File Changes:

**Line no. 33** defines a function to clear the input field and **line no. 46** calls the function on pressing `<Enter>`.

**Line no. 23**:
    If we type the name of a note without pressing `<Enter>` and switch to a different note, still the name typed should not persist. So on `focusout` event, we need to call the `cleanField(e)` function.

This solves #175.