### PR TITLE
Solves the problem of viewport change after pasting text

### DIFF
--- a/app/controllers/editor.coffee
+++ b/app/controllers/editor.coffee
@@ -202,7 +202,7 @@ class Editor extends Spine.Controller
   keydown: (e) ->
     # Some keys are special
     if e.keyCode is 13 #return
-      e.preventDefault()
+      #e.preventDefault()
       @insertText "\n"
     else if e.keyCode is 9 #tab
       e.preventDefault()
@@ -216,7 +216,7 @@ class Editor extends Spine.Controller
     @range = window.getSelection().getRangeAt(0)
 
     # Paste it into a textarea (removes formatting)
-    @psuedoinput.val("").focus()
+    #@psuedoinput.val("").focus()
 
     # As the paste event isn't instant, put it back in a few secs.
     setTimeout( =>


### PR DESCRIPTION
This solves #190.  But what was the original reason to put the line `@psuedoinput.val("").focus()`?

Also, there was a different problem. When you press `<Enter>`, in editor, the `\n` character was added but the viewport didn't change. I think this was due to the fact that when `<Enter>` is pressed, the handler prevents default actions. So `atom-shell` doesn't know about this event and doesn't change the viewport. So I commented this line too.

Closes #190, #106.